### PR TITLE
feat: add compilePartialCss function

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ Compiles CSS using Tailwind CSS 4.
 
 **Returns**: `Promise<string>` - Compiled CSS
 
+#### `compilePartialCss()`
+
+Compiles CSS using Tailwind CSS 4 from a CSS string containing `@apply`
+directives.
+
+| Parameter          | Type     | Description                    |
+| ------------------ | -------- | ------------------------------ |
+| `css`              | `string` | CSS string to process.         |
+| `configurationCss` | `string` | Tailwind v4 configuration CSS. |
+
+**Returns**: `Promise<string>` - Compiled CSS
+
 #### `transformCss()`
 
 Transforms CSS for browser compatibility.

--- a/src/compile-css.test.ts
+++ b/src/compile-css.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import compileCss from "./compile-css.js";
+import compileCss, { compileComponentCss } from "./compile-css.js";
 
 it("compiled css should contain standard tailwindcss layers", async () => {
   const compiledCss = await compileCss([], "", { addPreflight: true });
@@ -12,4 +12,27 @@ it("compiled css should contain standard tailwindcss layers", async () => {
 it("compiled css should contain standard tailwindcss layers order declaration", async () => {
   const compiledCss = await compileCss([], "", { addPreflight: true });
   expect(compiledCss).toContain("@layer theme, base, components, utilities;");
+});
+
+it("compiled component css should contain styles of classes from @apply rules", async () => {
+  const componentCss = `.test { @apply text-red-500; }`;
+  const configurationCss = ``; // No custom configuration.
+  const compiledCss = await compileComponentCss(componentCss, configurationCss)
+    // Remove line breaks for easier testing.
+    .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
+  expect(compiledCss).toContain(
+    `.test {  color: var(--color-red-500, oklch(63.7% 0.237 25.331));}`,
+  );
+});
+
+it("compiled component css should be able to use values from customized configuration", async () => {
+  const componentCss = `.test { @apply text-coffee; }`;
+  // Add custom color definition.
+  const configurationCss = `@theme { --color-coffee: #6f4e37; }`;
+  const compiledCss = await compileComponentCss(componentCss, configurationCss)
+    // Remove line breaks for easier testing.
+    .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
+  expect(compiledCss).toContain(
+    `.test {  color: var(--color-coffee, #6f4e37);}`,
+  );
 });

--- a/src/compile-css.test.ts
+++ b/src/compile-css.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import compileCss, { compileComponentCss } from "./compile-css.js";
+import compileCss, { compilePartialCss } from "./compile-css.js";
 
 it("compiled css should contain standard tailwindcss layers", async () => {
   const compiledCss = await compileCss([], "", { addPreflight: true });
@@ -14,10 +14,10 @@ it("compiled css should contain standard tailwindcss layers order declaration", 
   expect(compiledCss).toContain("@layer theme, base, components, utilities;");
 });
 
-it("compiled component css should contain styles of classes from @apply rules", async () => {
-  const componentCss = `.test { @apply text-red-500; }`;
+it("compiled partial css should contain styles of classes from @apply rules", async () => {
+  const css = `.test { @apply text-red-500; }`;
   const configurationCss = ``; // No custom configuration.
-  const compiledCss = await compileComponentCss(componentCss, configurationCss)
+  const compiledCss = await compilePartialCss(css, configurationCss)
     // Remove line breaks for easier testing.
     .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
   expect(compiledCss).toContain(
@@ -25,11 +25,11 @@ it("compiled component css should contain styles of classes from @apply rules", 
   );
 });
 
-it("compiled component css should be able to use values from customized configuration", async () => {
-  const componentCss = `.test { @apply text-coffee; }`;
+it("compiled partial css should be able to use values from customized configuration", async () => {
+  const css = `.test { @apply text-coffee; }`;
   // Add custom color definition.
   const configurationCss = `@theme { --color-coffee: #6f4e37; }`;
-  const compiledCss = await compileComponentCss(componentCss, configurationCss)
+  const compiledCss = await compilePartialCss(css, configurationCss)
     // Remove line breaks for easier testing.
     .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
   expect(compiledCss).toContain(

--- a/src/compile-css.test.ts
+++ b/src/compile-css.test.ts
@@ -36,3 +36,21 @@ it("compiled partial css should be able to use values from customized configurat
     `.test {  color: var(--color-coffee, #6f4e37);}`,
   );
 });
+
+it("compiled partial css should only use theme variables from customized configuration", async () => {
+  const css = `.test { @apply text-red-500; } .test2 { @apply text-coffee; }`;
+  const configurationCss = `
+    @theme { --color-coffee: #6f4e37; }
+    body { overflow-y: hidden; }
+  `;
+  const compiledCss = await compilePartialCss(css, configurationCss)
+    // Remove line breaks for easier testing.
+    .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
+  expect(compiledCss).toContain(
+    `.test {  color: var(--color-red-500, oklch(63.7% 0.237 25.331));}`,
+  );
+  expect(compiledCss).toContain(
+    `.test2 {  color: var(--color-coffee, #6f4e37);}`,
+  );
+  expect(compiledCss).not.toContain("body");
+});

--- a/src/compile-css.test.ts
+++ b/src/compile-css.test.ts
@@ -15,7 +15,7 @@ it("compiled css should contain standard tailwindcss layers order declaration", 
 });
 
 it("compiled partial css should contain styles of classes from @apply rules", async () => {
-  const css = `.test { @apply text-red-500; }`;
+  const css = `.test { @apply text-red-500; } .test2 { border-radius: 10px; }`;
   const configurationCss = ``; // No custom configuration.
   const compiledCss = await compilePartialCss(css, configurationCss)
     // Remove line breaks for easier testing.
@@ -23,6 +23,7 @@ it("compiled partial css should contain styles of classes from @apply rules", as
   expect(compiledCss).toContain(
     `.test {  color: var(--color-red-500, oklch(63.7% 0.237 25.331));}`,
   );
+  expect(compiledCss).toContain(`.test2 {  border-radius: 10px;}`);
 });
 
 it("compiled partial css should be able to use values from customized configuration", async () => {

--- a/src/compile-css.ts
+++ b/src/compile-css.ts
@@ -89,10 +89,10 @@ function prepareTailwindConfiguration(
 }
 
 /**
- * Compiles component CSS that uses `@apply` directives.
+ * Compiles partial CSS that uses `@apply` directives.
  * @see https://tailwindcss.com/docs/functions-and-directives#apply-directive
  *
- * @param componentCss - The CSS containing `@apply` directives. Normally this
+ * @param css - The CSS containing `@apply` directives. Normally this
  *     would also contain `@reference` to the Tailwind configuration, but here
  *     the configuration is provided via `configurationCss` parameter.
  *     @see https://tailwindcss.com/docs/functions-and-directives#reference-directive
@@ -109,15 +109,15 @@ function prepareTailwindConfiguration(
  *     can override in Tailwind 4's default theme.
  *     @see https://tailwindcss.com/docs/theme#default-theme-variable-reference
  */
-export async function compileComponentCss(
-  componentCss: string,
+export async function compilePartialCss(
+  css: string,
   configurationCss: string,
 ): Promise<string> {
   const tailwindConfiguration = prepareTailwindConfiguration(configurationCss);
   const compiler = await tailwindV4Compile(
     `
     @reference "${configurationCssId}";
-    ${componentCss}
+    ${css}
     `,
     { loadStylesheet: createStylesheetLoader(tailwindConfiguration) },
   );

--- a/src/compile-css.ts
+++ b/src/compile-css.ts
@@ -56,6 +56,13 @@ async function loadStylesheet(id: string, base: string) {
 
 const configurationCssId = "tailwindcss-in-browser/configuration";
 
+/**
+ * Creates a stylesheet loader for the Tailwind CSS compiler.
+ *
+ * @param configurationCss - CSS that acts as the Tailwind V4 configuration, with
+ *     no @import or @layer at-rules.
+ * @returns The stylesheet loader.
+ */
 function createStylesheetLoader(configurationCss?: string) {
   return async (id: string, base: string) => {
     if (configurationCss && id === configurationCssId) {
@@ -69,6 +76,14 @@ function createStylesheetLoader(configurationCss?: string) {
   };
 }
 
+/**
+ * Prepares CSS with @layer and @import at-rules for compiling Tailwind CSS.
+ *
+ * @param configurationCss - CSS that acts as the Tailwind V4 configuration, with
+ *     no @import or @layer at-rules.
+ * @param addPreflight - Whether to add the Preflight layer.
+ * @returns The prepared CSS with @layer and @import at-rules.
+ */
 function prepareTailwindConfiguration(
   configurationCss: string,
   addPreflight = true,
@@ -96,13 +111,13 @@ function prepareTailwindConfiguration(
  *     would also contain `@reference` to the Tailwind configuration, but here
  *     the configuration is provided via `configurationCss` parameter.
  *     @see https://tailwindcss.com/docs/functions-and-directives#reference-directive
- * @param [configurationCss] - CSS that acts as the Tailwind V4 configuration,
+ * @param configurationCss - CSS that acts as the Tailwind V4 configuration,
  *     as well as any additional CSS. This is where you would normally add
  *     `@import "tailwindcss"`, which imports the followings:
  *       - the default theme,
  *         @see https://tailwindcss.com/docs/theme#default-theme-variable-reference
  *       - the `base`/`preflight` layer,
- *       - the `components` layer —yet to be implemented in Tailwind 4—, and
+ *       - the `components` layer, and
  *       - the `utilities` layer.
  *     All of the above are already taken care of in this function. All you need
  *     to do is add your customizations with a `@theme` directive. See what you
@@ -146,7 +161,7 @@ export interface CompileCssOptions {
  * @see https://github.com/tailwindlabs/tailwindcss/blob/v4.1.13/packages/tailwindcss/src/index.ts#L699
  *
  * @param classNameCandidates - The class name candidates for compilation.
- * @param [configurationCss] - CSS that acts as the Tailwind V4 configuration,
+ * @param configurationCss - CSS that acts as the Tailwind V4 configuration,
  *     as well as any additional CSS. This is where you would normally add
  *     `@import "tailwindcss"`, which imports the followings:
  *       - the default theme,

--- a/src/compile-css.ts
+++ b/src/compile-css.ts
@@ -54,7 +54,22 @@ async function loadStylesheet(id: string, base: string) {
   throw new Error(`The browser build does not support @import for "${id}"`);
 }
 
-async function prepareTailwindConfiguration(
+const configurationCssId = "tailwindcss-in-browser/configuration";
+
+function createStylesheetLoader(configurationCss?: string) {
+  return async (id: string, base: string) => {
+    if (configurationCss && id === configurationCssId) {
+      return {
+        path: `virtual:${configurationCssId}.css`,
+        base,
+        content: configurationCss,
+      };
+    }
+    return loadStylesheet(id, base);
+  };
+}
+
+function prepareTailwindConfiguration(
   configurationCss: string,
   addPreflight = true,
 ): string {
@@ -71,6 +86,44 @@ async function prepareTailwindConfiguration(
     @import "tailwindcss/utilities.css" layer(utilities);
     ${configurationCssWithoutImports}
     `;
+}
+
+/**
+ * Compiles component CSS that uses `@apply` directives.
+ * @see https://tailwindcss.com/docs/functions-and-directives#apply-directive
+ *
+ * @param componentCss - The CSS containing `@apply` directives. Normally this
+ *     would also contain `@reference` to the Tailwind configuration, but here
+ *     the configuration is provided via `configurationCss` parameter.
+ *     @see https://tailwindcss.com/docs/functions-and-directives#reference-directive
+ * @param [configurationCss] - CSS that acts as the Tailwind V4 configuration,
+ *     as well as any additional CSS. This is where you would normally add
+ *     `@import "tailwindcss"`, which imports the followings:
+ *       - the default theme,
+ *         @see https://tailwindcss.com/docs/theme#default-theme-variable-reference
+ *       - the `base`/`preflight` layer,
+ *       - the `components` layer —yet to be implemented in Tailwind 4—, and
+ *       - the `utilities` layer.
+ *     All of the above are already taken care of in this function. All you need
+ *     to do is add your customizations with a `@theme` directive. See what you
+ *     can override in Tailwind 4's default theme.
+ *     @see https://tailwindcss.com/docs/theme#default-theme-variable-reference
+ */
+export async function compileComponentCss(
+  componentCss: string,
+  configurationCss: string,
+): Promise<string> {
+  const tailwindConfiguration = prepareTailwindConfiguration(configurationCss);
+  const compiler = await tailwindV4Compile(
+    `
+    @reference "${configurationCssId}";
+    ${componentCss}
+    `,
+    { loadStylesheet: createStylesheetLoader(tailwindConfiguration) },
+  );
+  // Component CSS does not need separate class name candidates,
+  // it provides class names via `@apply` directives.
+  return compiler.build([]);
 }
 
 /**
@@ -120,7 +173,7 @@ export default async function compileCss(
 ): Promise<string> {
   const compiler = await tailwindV4Compile(
     prepareTailwindConfiguration(configurationCss, addPreflight),
-    { loadStylesheet },
+    { loadStylesheet: createStylesheetLoader() },
   );
   return compiler.build(classNameCandidates);
 }

--- a/src/compile-css.ts
+++ b/src/compile-css.ts
@@ -54,6 +54,25 @@ async function loadStylesheet(id: string, base: string) {
   throw new Error(`The browser build does not support @import for "${id}"`);
 }
 
+async function prepareTailwindConfiguration(
+  configurationCss: string,
+  addPreflight = true,
+): string {
+  // Import at-rules need to be at the top of the CSS.
+  const { cssWithoutImports: configurationCssWithoutImports, importRules } =
+    extractImports(configurationCss);
+  // Since preflight can be disabled, we need to import each layer explicitly,
+  // instead of just `@import "tailwindcss"`.
+  return `
+    ${importRules}
+    @layer theme, base, components, utilities;
+    @import "tailwindcss/theme.css" layer(theme);
+    ${addPreflight ? '@import "tailwindcss/preflight.css" layer(base);' : ""}
+    @import "tailwindcss/utilities.css" layer(utilities);
+    ${configurationCssWithoutImports}
+    `;
+}
+
 /**
  * Options for compiling CSS.
  * @see {compileCss}
@@ -99,20 +118,8 @@ export default async function compileCss(
   configurationCss: string,
   { addPreflight = true }: CompileCssOptions = {},
 ): Promise<string> {
-  // Import at-rules need to be at the top of the CSS.
-  const { cssWithoutImports: configurationCssWithoutImports, importRules } =
-    extractImports(configurationCss);
   const compiler = await tailwindV4Compile(
-    // Since preflight can be disabled, we need to import each layer explicitly,
-    // instead of just `@import "tailwindcss"`.
-    `
-    ${importRules}
-    @layer theme, base, components, utilities;
-    @import "tailwindcss/theme.css" layer(theme);
-    ${addPreflight ? '@import "tailwindcss/preflight.css" layer(base);' : ""}
-    @import "tailwindcss/utilities.css" layer(utilities);
-    ${configurationCssWithoutImports}
-    `,
+    prepareTailwindConfiguration(configurationCss, addPreflight),
     { loadStylesheet },
   );
   return compiler.build(classNameCandidates);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,16 @@
 import buildCss from "./build-css.js";
-import compileCss, { type CompileCssOptions } from "./compile-css.js";
+import compileCss, {
+  compileComponentCss,
+  type CompileCssOptions,
+} from "./compile-css.js";
 import extractClassNameCandidates from "./extract-class-name-candidates.js";
 import transformCss, { type TransformCssOptions } from "./transform-css.js";
 
-export { extractClassNameCandidates, compileCss, transformCss };
+export {
+  extractClassNameCandidates,
+  compileCss,
+  compileComponentCss,
+  transformCss,
+};
 export type { CompileCssOptions, TransformCssOptions };
 export default buildCss;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import buildCss from "./build-css.js";
 import compileCss, {
-  compileComponentCss,
+  compilePartialCss,
   type CompileCssOptions,
 } from "./compile-css.js";
 import extractClassNameCandidates from "./extract-class-name-candidates.js";
@@ -9,7 +9,7 @@ import transformCss, { type TransformCssOptions } from "./transform-css.js";
 export {
   extractClassNameCandidates,
   compileCss,
-  compileComponentCss,
+  compilePartialCss,
   transformCss,
 };
 export type { CompileCssOptions, TransformCssOptions };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  // Load CSS files as text during tests.
+  plugins: [
+    {
+      name: "css-as-text",
+      enforce: "pre",
+      resolveId(id) {
+        return id.endsWith(".css") ? `${id}?raw` : null;
+      },
+    },
+  ],
+  test: {
+    css: { include: /.+/ },
+  },
+});


### PR DESCRIPTION
Depends on https://github.com/balintbrews/tailwindcss-in-browser/pull/17.

Adds the `compileComponentCss(componentCss: string, configurationCss: string)` function for compiling separate components' CSS that contain [`@apply`](https://tailwindcss.com/docs/functions-and-directives#apply-directive) directives.

This should allow for implementation of https://www.drupal.org/project/canvas/issues/3535689.