### PR TITLE
feat(compile-css): add option for unlayered utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,10 @@ Transforms CSS for browser compatibility.
 
 #### `CompileCssOptions`
 
-| Option         | Type      | Default | Description                                                                               |
-| -------------- | --------- | ------- | ----------------------------------------------------------------------------------------- |
-| `addPreflight` | `boolean` | `true`  | Whether to include [Tailwind's Preflight styles](https://tailwindcss.com/docs/preflight). |
+| Option               | Type       | Default | Description                                                                                            |
+| -------------------- | ---------- | ------- | ------------------------------------------------------------------------------------------------------ |
+| `addPreflight`       | `boolean`  | `true`  | Whether to include [Tailwind's Preflight styles](https://tailwindcss.com/docs/preflight).              |
+| `unlayeredUtilities` | `string[]` | `[]`    | Array of utility class names whose compiled CSS should not be placed in the `utilities` cascade layer. |
 
 #### `TransformCssOptions`
 

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -2,7 +2,7 @@
 import buildCss from "../tailwindcss-in-browser-dist/index.js";
 
 const markup = `
-        <div class="mx-auto flex md:grid mt-2 font-serif text-lg text-red-400 bg-yellow-500 text-shadow-lg hover:underline"></div>
+        <div class="mx-auto hidden md:flex md:grid mt-2 font-serif text-lg text-red-400 bg-yellow-500 text-shadow-lg hover:underline"></div>
       `;
 
 const css = `
@@ -14,6 +14,9 @@ const css = `
         }
       `;
 void buildCss(markup, css, {
-  compileCssOptions: { addPreflight: false },
+  compileCssOptions: {
+    addPreflight: false,
+    unlayeredUtilities: ["block", "flex"],
+  },
   transformCssOptions: { minify: false },
 }).then(console.log);

--- a/src/compile-css.test.ts
+++ b/src/compile-css.test.ts
@@ -1,57 +1,278 @@
-import { expect, it } from "vitest";
-import compileCss, { compilePartialCss } from "./compile-css.js";
+import { describe, expect, it } from "vitest";
+import compileCss, {
+  compilePartialCss,
+  splitClassNameCandidates,
+} from "./compile-css.js";
 
-it("compiled css should contain standard tailwindcss layers", async () => {
-  const compiledCss = await compileCss([], "", { addPreflight: true });
-  const standardLayers = ["theme", "base", "utilities"];
-  standardLayers.forEach((layer) => {
-    expect(compiledCss).toContain(`@layer ${layer}`);
+describe("compiled CSS", () => {
+  it("should contain standard tailwindcss layers", async () => {
+    const compiledCss = await compileCss([], "", { addPreflight: true });
+    const standardLayers = ["theme", "base", "utilities"];
+    standardLayers.forEach((layer) => {
+      expect(compiledCss).toContain(`@layer ${layer}`);
+    });
+  });
+
+  it("should contain standard tailwindcss layers order declaration", async () => {
+    const compiledCss = await compileCss([], "", { addPreflight: true });
+    expect(compiledCss).toContain("@layer theme, base, components, utilities;");
+  });
+
+  it("should compile unlayered utilities outside of utilities layer", async () => {
+    const compiledCss = await compileCss(["block", "text-red-500"], "", {
+      addPreflight: false,
+      unlayeredUtilities: ["block"],
+    });
+
+    expect(compiledCss).toMatchInlineSnapshot(`
+      "/*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
+      @layer theme, base, components, utilities;
+      @layer theme {
+        :root, :host {
+          --color-red-500: oklch(63.7% 0.237 25.331);
+        }
+      }
+      @layer utilities {
+        .text-red-500 {
+          color: var(--color-red-500);
+        }
+      }
+
+      /*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
+      .block {
+        display: block;
+      }
+      "
+    `);
+  });
+
+  it("should handle variants with unlayered utilities", async () => {
+    const compiledCss = await compileCss(
+      ["block", "md:block", "dark:block", "text-red-500"],
+      "",
+      { addPreflight: false, unlayeredUtilities: ["block"] },
+    );
+
+    expect(compiledCss).toMatchInlineSnapshot(`
+      "/*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
+      @layer theme, base, components, utilities;
+      @layer theme {
+        :root, :host {
+          --color-red-500: oklch(63.7% 0.237 25.331);
+        }
+      }
+      @layer utilities {
+        .text-red-500 {
+          color: var(--color-red-500);
+        }
+      }
+
+      /*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
+      .block {
+        display: block;
+      }
+      .md\\:block {
+        @media (width >= 48rem) {
+          display: block;
+        }
+      }
+      .dark\\:block {
+        @media (prefers-color-scheme: dark) {
+          display: block;
+        }
+      }
+      "
+    `);
+  });
+
+  it("should handle multiple unlayered utilities", async () => {
+    const compiledCss = await compileCss(
+      ["block", "flex", "text-red-500", "p-4"],
+      "",
+      { addPreflight: false, unlayeredUtilities: ["block", "flex"] },
+    );
+
+    expect(compiledCss).toMatchInlineSnapshot(`
+      "/*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
+      @layer theme, base, components, utilities;
+      @layer theme {
+        :root, :host {
+          --color-red-500: oklch(63.7% 0.237 25.331);
+          --spacing: 0.25rem;
+        }
+      }
+      @layer utilities {
+        .p-4 {
+          padding: calc(var(--spacing) * 4);
+        }
+        .text-red-500 {
+          color: var(--color-red-500);
+        }
+      }
+
+      /*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
+      .block {
+        display: block;
+      }
+      .flex {
+        display: flex;
+      }
+      "
+    `);
+  });
+
+  it("should handle empty unlayeredUtilities (default behavior)", async () => {
+    const compiledCss = await compileCss(["block", "text-red-500"], "", {
+      addPreflight: false,
+      unlayeredUtilities: [],
+    });
+
+    expect(compiledCss).toMatchInlineSnapshot(`
+      "/*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
+      @layer theme, base, components, utilities;
+      @layer theme {
+        :root, :host {
+          --color-red-500: oklch(63.7% 0.237 25.331);
+        }
+      }
+      @layer utilities {
+        .block {
+          display: block;
+        }
+        .text-red-500 {
+          color: var(--color-red-500);
+        }
+      }
+      "
+    `);
+  });
+
+  it("should handle arbitrary variants with unlayered utilities", async () => {
+    const compiledCss = await compileCss(
+      ["block", "[&>p]:block", "hover:block", "text-red-500"],
+      "",
+      { addPreflight: false, unlayeredUtilities: ["block"] },
+    );
+
+    expect(compiledCss).toMatchInlineSnapshot(`
+      "/*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
+      @layer theme, base, components, utilities;
+      @layer theme {
+        :root, :host {
+          --color-red-500: oklch(63.7% 0.237 25.331);
+        }
+      }
+      @layer utilities {
+        .text-red-500 {
+          color: var(--color-red-500);
+        }
+      }
+
+      /*! tailwindcss v4.1.13 | MIT License | https://tailwindcss.com */
+      .block {
+        display: block;
+      }
+      .hover\\:block {
+        &:hover {
+          @media (hover: hover) {
+            display: block;
+          }
+        }
+      }
+      .\\[\\&\\>p\\]\\:block {
+        &>p {
+          display: block;
+        }
+      }
+      "
+    `);
   });
 });
 
-it("compiled css should contain standard tailwindcss layers order declaration", async () => {
-  const compiledCss = await compileCss([], "", { addPreflight: true });
-  expect(compiledCss).toContain("@layer theme, base, components, utilities;");
-});
+describe("compiled partial CSS", () => {
+  it("should contain styles of classes from @apply rules", async () => {
+    const css = `.test { @apply text-red-500; } .test2 { border-radius: 10px; }`;
+    const configurationCss = ``; // No custom configuration.
+    const compiledCss = await compilePartialCss(css, configurationCss)
+      // Remove line breaks for easier testing.
+      .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
+    expect(compiledCss).toContain(
+      `.test {  color: var(--color-red-500, oklch(63.7% 0.237 25.331));}`,
+    );
+    expect(compiledCss).toContain(`.test2 {  border-radius: 10px;}`);
+  });
 
-it("compiled partial css should contain styles of classes from @apply rules", async () => {
-  const css = `.test { @apply text-red-500; } .test2 { border-radius: 10px; }`;
-  const configurationCss = ``; // No custom configuration.
-  const compiledCss = await compilePartialCss(css, configurationCss)
-    // Remove line breaks for easier testing.
-    .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
-  expect(compiledCss).toContain(
-    `.test {  color: var(--color-red-500, oklch(63.7% 0.237 25.331));}`,
-  );
-  expect(compiledCss).toContain(`.test2 {  border-radius: 10px;}`);
-});
+  it("should be able to use values from customized configuration", async () => {
+    const css = `.test { @apply text-coffee; }`;
+    // Add custom color definition.
+    const configurationCss = `@theme { --color-coffee: #6f4e37; }`;
+    const compiledCss = await compilePartialCss(css, configurationCss)
+      // Remove line breaks for easier testing.
+      .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
+    expect(compiledCss).toContain(
+      `.test {  color: var(--color-coffee, #6f4e37);}`,
+    );
+  });
 
-it("compiled partial css should be able to use values from customized configuration", async () => {
-  const css = `.test { @apply text-coffee; }`;
-  // Add custom color definition.
-  const configurationCss = `@theme { --color-coffee: #6f4e37; }`;
-  const compiledCss = await compilePartialCss(css, configurationCss)
-    // Remove line breaks for easier testing.
-    .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
-  expect(compiledCss).toContain(
-    `.test {  color: var(--color-coffee, #6f4e37);}`,
-  );
-});
-
-it("compiled partial css should only use theme variables from customized configuration", async () => {
-  const css = `.test { @apply text-red-500; } .test2 { @apply text-coffee; }`;
-  const configurationCss = `
+  it("should only use theme variables from customized configuration", async () => {
+    const css = `.test { @apply text-red-500; } .test2 { @apply text-coffee; }`;
+    const configurationCss = `
     @theme { --color-coffee: #6f4e37; }
     body { overflow-y: hidden; }
   `;
-  const compiledCss = await compilePartialCss(css, configurationCss)
-    // Remove line breaks for easier testing.
-    .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
-  expect(compiledCss).toContain(
-    `.test {  color: var(--color-red-500, oklch(63.7% 0.237 25.331));}`,
-  );
-  expect(compiledCss).toContain(
-    `.test2 {  color: var(--color-coffee, #6f4e37);}`,
-  );
-  expect(compiledCss).not.toContain("body");
+    const compiledCss = await compilePartialCss(css, configurationCss)
+      // Remove line breaks for easier testing.
+      .then((css) => css.replace(/(\r\n|\n|\r)/gm, ""));
+    expect(compiledCss).toContain(
+      `.test {  color: var(--color-red-500, oklch(63.7% 0.237 25.331));}`,
+    );
+    expect(compiledCss).toContain(
+      `.test2 {  color: var(--color-coffee, #6f4e37);}`,
+    );
+    expect(compiledCss).not.toContain("body");
+  });
+});
+
+describe("splitting class name candidates", () => {
+  it("should return layered and unlayered groups of candidates", () => {
+    const result = splitClassNameCandidates(
+      ["block", "md:block", "dark:block", "text-red-500", "p-4"],
+      ["block"],
+    );
+    expect(result.layered).toEqual(["text-red-500", "p-4"]);
+    expect(result.unlayered).toEqual(["block", "md:block", "dark:block"]);
+  });
+
+  it("should handle empty unlayeredUtilities", () => {
+    const result = splitClassNameCandidates(
+      ["block", "md:block", "text-red-500"],
+      [],
+    );
+    expect(result.layered).toEqual(["block", "md:block", "text-red-500"]);
+    expect(result.unlayered).toEqual([]);
+  });
+
+  it("should handle empty candidates", () => {
+    const result = splitClassNameCandidates([], ["block"]);
+    expect(result.layered).toEqual([]);
+    expect(result.unlayered).toEqual([]);
+  });
+
+  it("should handle multiple unlayeredUtilities", () => {
+    const result = splitClassNameCandidates(
+      ["block", "md:block", "flex", "lg:flex", "text-red-500", "p-4"],
+      ["block", "flex", "inline"],
+    );
+    expect(result.layered).toEqual(["text-red-500", "p-4"]);
+    expect(result.unlayered).toEqual(["block", "md:block", "flex", "lg:flex"]);
+  });
+
+  it("should handle arbitrary variants", () => {
+    const result = splitClassNameCandidates(
+      ["block", "[&>p]:block", "hover:block", "text-red-500"],
+      ["block"],
+    );
+    expect(result.layered).toEqual(["text-red-500"]);
+    expect(result.unlayered).toEqual(["block", "[&>p]:block", "hover:block"]);
+  });
 });

--- a/src/compile-css.ts
+++ b/src/compile-css.ts
@@ -151,6 +151,45 @@ export interface CompileCssOptions {
    * @see https://tailwindcss.com/docs/preflight
    */
   addPreflight?: boolean;
+  /**
+   * Array of utility class names where the compiled definitions should not be
+   * placed in a CSS cascade layer (i.e. `@layer utilities`).
+   * Class name candidates that end with any of these utility names (e.g., "block",
+   * "md:block", "dark:block" would all match "block") will not be placed in the
+   * `utilities` layer.
+   */
+  unlayeredUtilities?: string[];
+}
+
+/**
+ * Splits class name candidates into layered and unlayered groups based on
+ * unlayered utilities.
+ *
+ * @param classNameCandidates - The class name candidates to split.
+ * @param unlayeredUtilities - Array of utility class names. Candidates that end
+ *     with any of these utilities will be placed in the unlayered group.
+ * @returns An object with `layered` and `unlayered` arrays of class names.
+ */
+export function splitClassNameCandidates(
+  classNameCandidates: string[],
+  unlayeredUtilities: string[],
+): { layered: string[]; unlayered: string[] } {
+  const layered: string[] = [];
+  const unlayered: string[] = [];
+
+  for (const candidate of classNameCandidates) {
+    // Check if this candidate ends with any of the unlayeredUtilities.
+    const shouldUnlayer = unlayeredUtilities.some((utility) =>
+      candidate.endsWith(utility),
+    );
+    if (shouldUnlayer) {
+      unlayered.push(candidate);
+    } else {
+      layered.push(candidate);
+    }
+  }
+
+  return { layered, unlayered };
 }
 
 /**
@@ -177,6 +216,7 @@ export interface CompileCssOptions {
  *     @see {CompileCssOptions.addPreflight}
  * @param options - Options for compiling the CSS.
  * @param [options.addPreflight=true] - @see {CompileCssOptions.addPreflight}
+ * @param [options.unlayeredUtilities] - @see {CompileCssOptions.unlayeredUtilities}
  *
  * @returns The compiled CSS. The syntax is modern CSS syntax that needs to be
  * transformed to ensure compatibility with older browsers.
@@ -184,11 +224,41 @@ export interface CompileCssOptions {
 export default async function compileCss(
   classNameCandidates: string[],
   configurationCss: string,
-  { addPreflight = true }: CompileCssOptions = {},
+  { addPreflight = true, unlayeredUtilities = [] }: CompileCssOptions = {},
 ): Promise<string> {
-  const compiler = await tailwindV4Compile(
-    prepareTailwindConfiguration(configurationCss, addPreflight),
-    { loadStylesheet: createStylesheetLoader() },
-  );
-  return compiler.build(classNameCandidates);
+  // Split classNameCandidates into layered and unlayered sets.
+  const { layered: layeredCandidates, unlayered: unlayeredCandidates } =
+    splitClassNameCandidates(classNameCandidates, unlayeredUtilities);
+
+  // Compile both sets.
+  const compilations = await Promise.all([
+    // Layered compilation (normal behavior):
+    // Always compile to preserve layer structure, even with empty candidates.
+    (async () => {
+      const compiler = await tailwindV4Compile(
+        prepareTailwindConfiguration(configurationCss, addPreflight),
+        { loadStylesheet: createStylesheetLoader() },
+      );
+      return compiler.build(layeredCandidates);
+    })(),
+    // Unlayered compilation:
+    // Only compile if there are unlayered candidates.
+    (async () => {
+      if (unlayeredCandidates.length === 0) {
+        return "";
+      }
+      // Prepare configuration for unlayered compilation.
+      const unlayeredConfiguration = `
+        @import "tailwindcss/theme.css" layer(theme);
+        @import "tailwindcss/utilities.css";
+      `;
+      const compiler = await tailwindV4Compile(unlayeredConfiguration, {
+        loadStylesheet: createStylesheetLoader(),
+      });
+      return compiler.build(unlayeredCandidates);
+    })(),
+  ]);
+
+  // Merge the results, filtering out empty strings
+  return compilations.filter((css) => css.length > 0).join("\n");
 }


### PR DESCRIPTION
Tailwind CSS 4 compiles the CSS with all the rules placed inside cascade layers. When there is other CSS outputted on the same page with unlayered rules, those take precendence, which can cause unintended side effects.

One of these problematic cases is when certain class names from the unlayered rules conflict with Tailwind CSS utilities. Tailwind allows [prefixing all generated classes and CSS variables](https://tailwindcss.com/docs/styling-with-utility-classes#using-the-prefix-option) exactly to avoid this, but using that configuration option means code can't be easily copied from UI component libraries, or can't be conveniently generated with AI tools without additional prompting.

### Example problem

Drupal core's [System module outputs](https://git.drupalcode.org/project/drupal/-/blob/ea75fec9563c807af124acf2d0a3b0950647e205/core/modules/system/css/components/hidden.module.css#L14) the following rule without a layer:

```
.hidden {
  display: none;
}
```

This conflicts with [Tailwind's `hidden` utility class](https://tailwindcss.com/docs/display). They both have the same declaration, so it wouldn't seem like a problem. However, consider the following situation:

```
<div class="hidden md:block"> … </div> 
```

The `block` utility class is added to set `display: block` from the medium screen size and up, but the unlayered rule with the `.hidden` class will always take precedence. To work around this, we'd need to add `md:!block` (notice the `!` which adds `!important` in the generated declaration). That workaround is not intuitive, and has the same problems stated above with configuring Tailwind to use a prefix.

### Idea

Here is an idea to overcome this. If there is a finite set of conflicting class names, we can identify the ones that affect the same property. With the example above, the property would be `display`. If all utility classes that deal with `display` would be outputted without a layer instead of living inside the `utilities` layer, they could properly take effect when they're used with a variant in addition to `hidden`.

This is what the PR does by allowing to pass a list of utility classes which will be placed outside of a layer in the compiled CSS. To fix the conflict with the unlayered `.hidden` class from the example above, this is how we would call the `compileCss` function:

```
const compiledCss = await compileTailwindCss(
  classNameCandidates,
  configurationCss,
  {
    unlayeredUtilities: [
      'inline',
      'block',
      'inline-block',
      'flow-root',
      'flex',
      'inline-flex',
      'grid',
      'inline-grid',
      'contents',
      'table',
      'inline-table',
      'table-caption',
      'table-cell',
      'table-column',
      'table-column-group',
      'table-footer-group',
      'table-header-group',
      'table-row-group',
      'table-row',
      'list-item',
    ],
  },
);
```