### PR TITLE
feat: transformCss no longer inits lightningcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./lightningcss_node.wasm": {
+      "import": "./dist/lightningcss_node.wasm"
     }
   },
   "files": [

--- a/src/__snapshots__/transform-css.test.ts.snap
+++ b/src/__snapshots__/transform-css.test.ts.snap
@@ -1,0 +1,5 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`transform CSS > CSS is minified 1`] = `".rule{font-weight:700}"`;
+
+exports[`transform CSS > invalid media queries are fixed 1`] = `"@media not all and (min-width:640px){.rule{font-weight:700}}"`;

--- a/src/build-css.ts
+++ b/src/build-css.ts
@@ -1,6 +1,17 @@
+import lightningCssInit from "lightningcss-wasm";
+import lightningCssWasm from "lightningcss-wasm/lightningcss_node.wasm?url";
 import compileCss, { type CompileCssOptions } from "./compile-css.js";
 import extractClassNameCandidates from "./extract-class-name-candidates.js";
 import transformCss, { type TransformCssOptions } from "./transform-css.js";
+
+/**
+ * Options for building CSS.
+ * @see {transformCss}
+ */
+export interface BuildCssOptions {
+  compileCssOptions?: CompileCssOptions;
+  transformCssOptions?: TransformCssOptions;
+}
 
 /**
  * Builds CSS with Tailwind V4 using the given markup and CSS configuration.
@@ -25,20 +36,14 @@ import transformCss, { type TransformCssOptions } from "./transform-css.js";
 export default async function buildCss(
   markup: string,
   configurationCss: string,
-  {
-    compileCssOptions,
-    transformCssOptions,
-  }: {
-    compileCssOptions?: CompileCssOptions;
-    transformCssOptions?: TransformCssOptions;
-  } = {},
+  { compileCssOptions, transformCssOptions }: BuildCssOptions = {},
 ): Promise<string> {
+  await lightningCssInit(new URL(lightningCssWasm, import.meta.url));
   const classNameCandidates = extractClassNameCandidates(markup);
   const compiledCss = await compileCss(
     classNameCandidates,
     configurationCss,
     compileCssOptions,
   );
-  const transformedCss = await transformCss(compiledCss, transformCssOptions);
-  return transformedCss;
+  return transformCss(compiledCss, transformCssOptions);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import lightningCssInit from "lightningcss-wasm";
 import buildCss from "./build-css.js";
 import compileCss, {
   compilePartialCss,
@@ -7,6 +8,7 @@ import extractClassNameCandidates from "./extract-class-name-candidates.js";
 import transformCss, { type TransformCssOptions } from "./transform-css.js";
 
 export {
+  lightningCssInit,
   extractClassNameCandidates,
   compileCss,
   compilePartialCss,

--- a/src/transform-css.test.ts
+++ b/src/transform-css.test.ts
@@ -1,0 +1,31 @@
+import lightningCssInit from "lightningcss-wasm";
+import lightningCssWasm from "lightningcss-wasm/lightningcss_node.wasm?url";
+import { beforeAll, describe, expect, it } from "vitest";
+import transformCss from "./transform-css.ts";
+
+describe("transform CSS", () => {
+  beforeAll(async () => {
+    await lightningCssInit(new URL(lightningCssWasm, import.meta.url));
+  });
+
+  it("CSS is minified", () => {
+    const css = transformCss(`
+/* A comment... */
+.rule {
+  font-weight: bold;
+}  
+`);
+    expect(css).toMatchSnapshot();
+  });
+
+  it("invalid media queries are fixed", () => {
+    const css = transformCss(`
+@media not (min-width: 640px) {
+  .rule {
+    font-weight: bold;
+  }  
+}
+`);
+    expect(css).toMatchSnapshot();
+  })
+});

--- a/src/transform-css.ts
+++ b/src/transform-css.ts
@@ -1,8 +1,7 @@
-import lightningCssInit, {
+import {
   Features as LightningCssFeatures,
   transform as lightningCssTransform,
 } from "lightningcss-wasm";
-import lightningCssWasm from "lightningcss-wasm/lightningcss_node.wasm";
 
 /**
  * Options for transforming CSS.
@@ -23,6 +22,8 @@ export interface TransformCssOptions {
  * Uses the WASM build of Lightning CSS to match the behavior of Tailwind 4's
  * CLI.
  *
+ * Lightning CSS must be loaded in the browser already.
+ *
  * @see https://github.com/tailwindlabs/tailwindcss/blob/v4.1.13/packages/%40tailwindcss-node/src/optimize.ts
  *
  * @param css - The CSS to transform.
@@ -31,12 +32,10 @@ export interface TransformCssOptions {
  *
  * @returns The transformed CSS.
  */
-export default async function transformCss(
+export default function transformCss(
   css: string,
   { minify = true }: TransformCssOptions = {},
-): Promise<string> {
-  await lightningCssInit(new URL(lightningCssWasm, import.meta.url).href);
-
+): string {
   function transform(code: Buffer | Uint8Array) {
     return lightningCssTransform({
       filename: "input.css",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,24 +1,4 @@
-import { readFile } from "fs/promises";
-import { createRequire } from "module";
-import path from "path";
 import { defineConfig } from "tsup";
-
-// Get the version of the `lightningcss-wasm` package. It will be added to the
-// bundled WASM file's filename in the `tsup` config below (`esbuildOptions` →
-// `assetNames`).
-const lightningCssWasmVersion = await (async (): Promise<string> => {
-  const require = createRequire(import.meta.url);
-  const lightningCssWasmPackagePath = require.resolve("lightningcss-wasm");
-  const lightningCssWasmPackageFullPath = path.join(
-    path.dirname(lightningCssWasmPackagePath),
-    "package.json",
-  );
-  return (
-    JSON.parse(await readFile(lightningCssWasmPackageFullPath, "utf8")) as {
-      version: string;
-    }
-  ).version;
-})();
 
 export default defineConfig({
   platform: "browser",
@@ -39,34 +19,17 @@ export default defineConfig({
     ".css": "text",
     ".wasm": "file",
   },
-  banner: {
-    // The LightningCSS WASM file is referenced in the codebase as
-    // `new URL(${wasmFilePath}, import.meta.url).href`, which is then passed to
-    // `lightningCssInit()` that uses `fetch` to load the WASM file. Bundlers
-    // used by consumers of this library (e.g. Vite) can't statically analyze
-    // that import, so the WASM file will not be included in the consumer's
-    // bundle.
-    // As a workaround, we add a statement to `index.js` to explicitly import
-    // the Lightning CSS WASM file as a URL. The `?url` suffix is used in the
-    // import statement to ensure the WASM file is loaded as a URL. This is
-    // recognized by the most commonly used bundlers.
-    // CAVEAT: The `banner` option can add an arbitrary to string to all
-    // generated JS and CSS files, but there is no way to limit it to only the
-    // `index.js` file. What's lucky is that it's the only generated JS file.
-    js: `import './lightningcss_node-${lightningCssWasmVersion}.wasm?url';`,
-  },
   esbuildOptions(options) {
     // By default esbuild generates a hash for the filename based on the file
     // contents, which would work well, but there is no easy way to access the
     // generated hash value, which we will also need in the `banner` option
-    // below. So instead the version of the `lightningcss-wasm` package is added
-    // to the filename, which we can also access in the `banner` option.
+    // below. So we remove that hash.
     // CAVEAT: This configuration option affects all bundled assets. There is no
     // way to only apply it to the Lightning CSS WASM file. (The
     // `esbuildOptions` function takes a `context` parameter besides `options`,
     // but it doesn't contain any information about the asset being bundled.)
     // What's lucky is that the Lightning CSS WASM file is the only bundled
     // asset file.
-    options.assetNames = `[name]-${lightningCssWasmVersion}`;
+    options.assetNames = `[name]`;
   },
 });


### PR DESCRIPTION
BREAKING CHANGE: lightningcss must be loaded manually if you are not using buildCss.